### PR TITLE
Possibilitar modo de debug

### DIFF
--- a/credenciais/.env.example
+++ b/credenciais/.env.example
@@ -1,4 +1,5 @@
 # .env
+DEBUG=True
 
 # [Twitter API Keys]
 CONSUMER_KEY =

--- a/credenciais/settings.py
+++ b/credenciais/settings.py
@@ -5,6 +5,7 @@ from pathlib import Path
 env_path = Path('./credenciais') / '.env'
 load_dotenv(dotenv_path=env_path, override=True)
 
+debug = os.getenv("DEBUG", False)
 # [Twitter API Keys]
 consumer_key = os.environ.get('CONSUMER_KEY')
 consumer_secret = os.environ.get('CONSUMER_SECRET')


### PR DESCRIPTION
Com isso, quem estiver desenvolvendo/melhorando o código não precisa
configurar todas as key e acessos externos

Isso evita também que a chave seja bloqueada enquanto estiver
desenvolvendo ou testando a aplicação

Para ativar o debug, apenas adicionar DEBUG=True no .env