### PR TITLE
[BUG] Corrigindo bug de tentativas

### DIFF
--- a/colaborabot.py
+++ b/colaborabot.py
@@ -136,7 +136,7 @@ def busca_disponibilidade_sites(sites):
     for row in sites:
         url, arroba, orgao = row.url, row.arroba, row.orgao
 
-        for tentativa in range(TOTAL_TENTATIVAS):
+        for tentativa in range(1, TOTAL_TENTATIVAS+1):
             try:
                 momento = datetime.datetime.now().isoformat(sep=' ', timespec='seconds')
                 resposta = get(url, timeout=30, headers=headers)


### PR DESCRIPTION
Existe um bug na aplicação relacionado a esse loop de tentativas que faz com que caso o numero de tentativas chegue a 10, o programa NUNCA entra dentro da condição da linha 149:

```python
if tentativa == TOTAL_TENTATIVAS:
    # esse trecho de código nunca é executado
    if not settings.debug:
        preenche_tab_gs(planilha=planilha_google, dados=dados)
    preenche_csv(arquivo_logs=arq_log, dados=dados)
    print(f"""{momento}; url: {url}; orgão: {orgao}; resposta: {resposta.status_code}""")
    if not settings.debug:
        checar_timelines(mastodon_handler=mastodon_bot, url=url, orgao=orgao)
```

O uso do `range` que está incorreto. 
```python
for tentativa in range(TOTAL_TENTATIVAS):
```
Ao usar `range(10)` a variável do `for` vai ser de 0 até 9, nunca chegando a 10. E como a condição da linha 149 verifica `se a tentativa for igual a 10` nunca vai entrar... porque é 9.

Por causa disso estou submetendo essa pequena mudança para análise.
```python
for tentativa in range(1, TOTAL_TENTATIVAS+1):
```
Esta alteração faz com que a variável do `for` seja inicializadas em 1 e vá até 10.