### PR TITLE
Cria função de tweetar que o site voltou ao ar

### DIFF
--- a/colaborabot.py
+++ b/colaborabot.py
@@ -23,6 +23,7 @@ headers = {
 
 TOTAL_TENTATIVAS = 10
 STATUS_SUCESSO = 200
+TEMPO_VERIFICACAO = 300
 
 # Guardando informações de hora e data da máquina
 
@@ -38,6 +39,22 @@ def criar_tweet(url, orgao):
     Criando o tweet com o status do site recém acessado
     """
     twitter_bot.update_status(lista_frases(url=url, orgao=orgao))
+
+def aviso_site_tweet(url, orgao):
+    """
+    Envia tweet avisando que o site voltou ao ar
+    """
+    site_no_ar = False
+    aviso = f"🤖 O portal com dados públicos {url} do órgão {orgao} voltou ao ar"
+
+    for tentativa in range(TOTAL_TENTATIVAS + 1):
+        resposta = get(url, timeout=30, headers=headers)
+        if resposta == STATUS_SUCESSO:
+            site_no_ar = True
+            break
+        sleep(TEMPO_VERIFICACAO)
+
+    twitter_bot.update_status(aviso) if site_no_ar else criar_tweet(url, orgao)
 
 
 def plan_gs(dia, mes, ano):

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -48,11 +48,14 @@ def aviso_site_tweet(url, orgao):
     aviso = f"🤖 O portal com dados públicos {url} do órgão {orgao} voltou ao ar"
 
     for tentativa in range(TOTAL_TENTATIVAS + 1):
-        resposta = get(url, timeout=30, headers=headers)
-        if resposta == STATUS_SUCESSO:
-            site_no_ar = True
-            break
-        sleep(TEMPO_VERIFICACAO)
+        try:
+            resposta = get(url, timeout=30, headers=headers)
+            if resposta.status_code == STATUS_SUCESSO:
+                site_no_ar = True
+                break
+            sleep(TEMPO_VERIFICACAO)
+        except(exceptions.ConnectionError, exceptions.Timeout, exceptions.TooManyRedirects):
+            print(f"Erro de conexão com {url} do {orgao}")
 
     twitter_bot.update_status(aviso) if site_no_ar else criar_tweet(url, orgao)
 


### PR DESCRIPTION

Resolve #18

### Descrição
Como os portais de transparência podem ser instáveis, duas coisas podem evitar que o bot passe a impressão de que está acusando erroneamente: 

- [X] Aumentar o período entre as 10 tentativas de entrar no site, ou a quantidade de tentativas, e
- [X] Enviar tweet avisando que foi verificado que o site voltou.

O que ainda pode ser feito a partir deste PR:
- [ ] Coletar esses dados e criar um ranking de portais mais instáveis, ou algo mais interessante.

### O que foi feito
Foi criado um método para enviar um tweet caso a url do órgão analisado não esteja no ar em um período de 10 tentativas no intervalo de verificação de 5 minutos.

