### PR TITLE
Refatoração no Colaborabot

### DIFF
--- a/autenticadores.py
+++ b/autenticadores.py
@@ -4,24 +4,61 @@ import settings
 import tweepy
 import json
 
+"""
+Braco
+    inicializacao (autenticação)
+    atualizar linha do tempo
+    checa linha do tempo
+"""
 
-def masto_auth():
-    mastodon = Mastodon(access_token=settings.mastodon_key, api_base_url="https://botsin.space")
-    return mastodon
+class BracoBase(): # classe abstrata base
+    pass
 
 
-def twitter_auth():
-    consumer_key = settings.consumer_key
-    consumer_secret = settings.consumer_secret
-    access_token = settings.access_token
-    access_token_secret = settings.access_token_secret
+class Twitter(BracoBase):
+    def __init__(self):
+        consumer_key = settings.consumer_key
+        consumer_secret = settings.consumer_secret
+        access_token = settings.access_token
+        access_token_secret = settings.access_token_secret
 
-    # App no Twitter
+        # App no Twitter
+        auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+        auth.set_access_token(access_token, access_token_secret)
+        self.bot = tweepy.API(auth)
 
-    auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
-    auth.set_access_token(access_token, access_token_secret)
-    bot = tweepy.API(auth)
-    return bot
+    def update(self, mensagem):
+        self.bot.update_status(status=mensagem)
+
+    def get_timeline(self, limite=10):
+        pass
+
+
+class Mastodon(BracoBase):
+    def __init__(self):
+        self.bot = Mastodon(access_token=settings.mastodon_key, api_base_url="https://botsin.space")
+
+    def update(self, checa_timeline=False, mensagem):
+        if checa_timeline and self.contem(mensagem):
+            self.bot.toot(mensagem)
+        else:
+            self.bot.toot(mensagem)
+
+    def get_timeline(self, limite=10):
+        return self.bot.timeline_home(limit=10)
+
+    def contem(mensagem):
+        timeline = self.bot.get_timeline_home(limit=10)
+        urls_postadas = [toot["content"] for toot in timeline]
+        return any(url in toot for toot in urls_postadas)
+
+
+class GoogleSheet(BracoBase):
+    pass
+
+
+class Telegram(BracoBase):
+    pass
 
 
 def google_api_auth(arqv_json="credenciais/colaborabot-gAPI.json", subject=None):
@@ -52,7 +89,7 @@ def google_api_auth(arqv_json="credenciais/colaborabot-gAPI.json", subject=None)
         header=header,
     )
 
-
+# TODO remover essa funcao
 def id_mastodon():
     id_perfil = settings.mastodon_profile_id
     return id_perfil

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -1,8 +1,11 @@
+from abc import ABC, abstractmethod
+
 from authlib.client import AssertionSession
 from mastodon import Mastodon
 import settings
 import tweepy
 import json
+
 
 """
 Braco
@@ -11,9 +14,14 @@ Braco
     checa linha do tempo
 """
 
-class BracoBase(): # classe abstrata base
-    pass
+class BracoBase(ABC): # classe abstrata base
+    @abstractmethod
+    def update(self, mensagem, checa_timeline=False):
+        pass
 
+    @abstractmethod
+    def get_timeline(self, limite=10):
+        pass
 
 class Twitter(BracoBase):
     def __init__(self):
@@ -27,7 +35,7 @@ class Twitter(BracoBase):
         auth.set_access_token(access_token, access_token_secret)
         self.bot = tweepy.API(auth)
 
-    def update(self, mensagem):
+    def update(self, mensagem, checa_timeline=False):
         self.bot.update_status(status=mensagem)
 
     def get_timeline(self, limite=10):
@@ -38,7 +46,7 @@ class Mastodon(BracoBase):
     def __init__(self):
         self.bot = Mastodon(access_token=settings.mastodon_key, api_base_url="https://botsin.space")
 
-    def update(self, checa_timeline=False, mensagem):
+    def update(self, mensagem, checa_timeline=False):
         if checa_timeline and self.contem(mensagem):
             self.bot.toot(mensagem)
         else:

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -158,6 +158,30 @@ class GoogleSheet(BracoBase):
 class Telegram(BracoBase):
     pass
 
+class CSV(BracoBase):
+    def __init__(self):
+        pasta_logs = Path("logs")
+        if not pasta_logs.exists():
+            pasta_logs.mkdir()
+
+        DIA = datetime.datetime.now().day
+        MES = datetime.datetime.now().month
+        ANO = datetime.datetime.now().year
+
+        self.arq_log = pasta_logs / f"colaborabot-log-{ANO}-{MES}-{DIA}.csv"
+        cabecalho = ["data_bsb", "data_utc", "url", "orgao", "cod_resposta"]
+        with open(self.arq_log, "w") as csvfile:
+            csv_writer = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
+            csv_writer.writerow(cabecalho)
+
+    def update(self, dados, checa_timeline=False):
+        with open(self.arq_log, "a") as csvfile:
+            csv_writer = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
+            mensagem = cria_dados(dados.url, dados.orgao, dados.resposta)
+            csv_writer.writerow(mensagem)
+
+    def get_timeline(self, limite=10):
+        pass
 
 def google_api_auth(arqv_json="credenciais/colaborabot-gAPI.json", subject=None):
     with open(arqv_json, "r") as f:

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -6,6 +6,11 @@ import settings
 import tweepy
 import json
 
+from pathlib import Path
+import datetime
+import csv
+
+from utils import cria_frase, cria_dados
 
 """
 Braco
@@ -16,7 +21,7 @@ Braco
 
 class BracoBase(ABC): # classe abstrata base
     @abstractmethod
-    def update(self, mensagem, checa_timeline=False):
+    def update(self, dados, checa_timeline=False):
         pass
 
     @abstractmethod
@@ -35,7 +40,10 @@ class Twitter(BracoBase):
         auth.set_access_token(access_token, access_token_secret)
         self.bot = tweepy.API(auth)
 
-    def update(self, mensagem, checa_timeline=False):
+    def update(self, dados, checa_timeline=False):
+        mensagem = cria_frase(url=dados["url"],
+                              orgao=dados["orgao"],
+                              resposta=["status_code"])
         self.bot.update_status(status=mensagem)
 
     def get_timeline(self, limite=10):
@@ -49,7 +57,10 @@ class Mastodon(BracoBase):
     def __init__(self):
         self.bot = Mastodon(access_token=settings.mastodon_key, api_base_url="https://botsin.space")
 
-    def update(self, mensagem, checa_timeline=False):
+    def update(self, dados, checa_timeline=False):
+        mensagem = cria_frase(url=dados["url"],
+                              orgao=dados["orgao"],
+                              resposta=["status_code"])
         if checa_timeline and self.contem(mensagem):
             self.bot.toot(mensagem)
         else:

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -40,6 +40,9 @@ class Twitter(BracoBase):
 
     def get_timeline(self, limite=10):
         pass
+        # Ver http://docs.tweepy.org/en/latest/api.html#API.home_timeline
+        # ou http://docs.tweepy.org/en/latest/code_snippet.html#pagination
+        #return self.bot.home_timeline(count=limite)
 
 
 class Mastodon(BracoBase):
@@ -53,7 +56,7 @@ class Mastodon(BracoBase):
             self.bot.toot(mensagem)
 
     def get_timeline(self, limite=10):
-        return self.bot.timeline_home(limit=10)
+        return self.bot.timeline_home(limit=limite)
 
     def contem(mensagem):
         timeline = self.bot.get_timeline_home(limit=10)
@@ -63,7 +66,6 @@ class Mastodon(BracoBase):
 
 class GoogleSheet(BracoBase):
     pass
-
 
 class Telegram(BracoBase):
     pass

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 
 from authlib.client import AssertionSession
-from mastodon import Mastodon
+
+import mastodon 
 import settings
 import tweepy
 import json
@@ -55,12 +56,12 @@ class Twitter(BracoBase):
 
 class Mastodon(BracoBase):
     def __init__(self):
-        self.bot = Mastodon(access_token=settings.mastodon_key, api_base_url="https://botsin.space")
+        self.bot = mastodon.Mastodon(access_token=settings.mastodon_key,
+                                     api_base_url="https://botsin.space")
 
     def update(self, dados, checa_timeline=False):
-        mensagem = cria_frase(url=dados["url"],
-                              orgao=dados["orgao"],
-                              resposta=["status_code"])
+        mensagem = cria_frase(url=dados.url,
+                              orgao=dados.orgao)
         if checa_timeline and self.contem(mensagem):
             self.bot.toot(mensagem)
         else:
@@ -69,8 +70,8 @@ class Mastodon(BracoBase):
     def get_timeline(self, limite=10):
         return self.bot.timeline_home(limit=limite)
 
-    def contem(mensagem):
-        timeline = self.get_timeline_home(limit=10)
+    def contem(self, mensagem):
+        timeline = self.get_timeline(limite=10)
         urls_postadas = [toot["content"] for toot in timeline]
         return any(url in toot for toot in urls_postadas)
 

--- a/autenticadores.py
+++ b/autenticadores.py
@@ -97,7 +97,3 @@ def google_api_auth(arqv_json="credenciais/colaborabot-gAPI.json", subject=None)
         header=header,
     )
 
-# TODO remover essa funcao
-def id_mastodon():
-    id_perfil = settings.mastodon_profile_id
-    return id_perfil

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -9,9 +9,13 @@ from pathlib import Path
 from time import sleep
 import settings
 
-from divulga import cria_frase, checar_timelines, google_sshet
+from collections import namedtuple
+
+from divulga import checar_timelines, google_sshet
 from autenticadores import google_api_auth
 from gspread.exceptions import APIError
+
+from utils import cria_frase
 
 http.client._MAXHEADERS = 1000
 
@@ -73,18 +77,6 @@ def plan_gs(dia, mes, ano):
     planilha.share(None, perm_type="anyone", role="reader")
     print(f"https://docs.google.com/spreadsheets/d/{planilha.id}\n")
     return planilha
-
-
-def cria_dados(url, portal, resposta):
-    """
-    Captura as informações de hora e data da máquina, endereço da página e
-    resposta recebida e as prepara dentro de uma lista para inserir na tabela.
-    """
-    formato_data = "%Y-%m-%d %H:%m:%S"
-    momento = str(datetime.datetime.now().strftime(formato_data))
-    momento_utc = datetime.datetime.utcnow().strftime(formato_data)
-    dados = [momento, momento_utc, url, portal, resposta]
-    return dados
 
 
 def preenche_csv(resultados):

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -36,6 +36,7 @@ ANO = datetime.datetime.now().year
 
 data = "{:02d}/{:02d}/{:02d}".format(DIA, MES, ANO)  # 11/04/2019
 
+# TODO remover
 def criar_tweet(url, orgao):
     """
     Criando o tweet com o status do site recém acessado
@@ -161,12 +162,10 @@ def busca_disponibilidade_sites(sites):
                         while not planilha_preenchida:
                             planilha_preenchida = preenche_tab_gs(planilha=planilha_google, dados=dados)
                         resultados.append(dados)
-                        checar_timelines(
-                            twitter_hander=twitter_bot,
-                            mastodon_handler=mastodon_bot,
-                            url=url,
-                            orgao=orgao,
-                        )
+                        
+                        for bots in settings.bracos:
+                            bot = bots()
+                            bot.update(checa_timeline=True, mensagem=lista_frases(url=url, orgao=orgao))
 
             except requests.exceptions.RequestException as e:
                 print("Tentativa {}:".format(tentativa + 1))
@@ -188,8 +187,10 @@ def busca_disponibilidade_sites(sites):
 
 if __name__ == "__main__":
     if not settings.debug:
+        """
         mastodon_bot = masto_auth()
         twitter_bot = twitter_auth()
+        """
         google_creds = google_api_auth()
         google_drive_creds = google_sshet()
         planilha_google = plan_gs(dia=DIA, mes=MES, ano=ANO)

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -10,7 +10,7 @@ from time import sleep
 import settings
 
 from divulga import cria_frase, checar_timelines, google_sshet
-from autenticadores import twitter_auth, google_api_auth, masto_auth
+from autenticadores import google_api_auth
 from gspread.exceptions import APIError
 
 http.client._MAXHEADERS = 1000
@@ -155,8 +155,8 @@ def busca_disponibilidade_sites(sites):
                             planilha_preenchida = preenche_tab_gs(planilha=planilha_google, dados=dados)
                         resultados.append(dados)
                         
-                        for bots in settings.bracos:
-                            bot = bots()
+                        global bots_ativos
+                        for bot in bots_ativos:
                             bot.update(checa_timeline=True, mensagem=cria_frase(url=url, orgao=orgao))
 
             except requests.exceptions.RequestException as e:
@@ -179,13 +179,13 @@ def busca_disponibilidade_sites(sites):
 
 if __name__ == "__main__":
     if not settings.debug:
-        """
-        mastodon_bot = masto_auth()
-        twitter_bot = twitter_auth()
-        """
-        google_creds = google_api_auth()
-        google_drive_creds = google_sshet()
-        planilha_google = plan_gs(dia=DIA, mes=MES, ano=ANO)
+        global bots_ativos
+        bots_ativos = (bot() for bot in settings.bracos)
+
+        #google_creds = google_api_auth()
+        #google_drive
+        #google_drive_creds = google_sshet()
+        #planilha_google = plan_gs(dia=DIA, mes=MES, ano=ANO)
     sites = carregar_dados_site()
     while True:
         busca_disponibilidade_sites(sites)

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -36,14 +36,6 @@ ANO = datetime.datetime.now().year
 
 data = "{:02d}/{:02d}/{:02d}".format(DIA, MES, ANO)  # 11/04/2019
 
-# TODO remover
-def criar_tweet(url, orgao):
-    """
-    Criando o tweet com o status do site recém acessado
-    """
-    twitter_bot.update_status(lista_frases(url=url, orgao=orgao))
-
-
 def plan_gs(dia, mes, ano):
     """
     Cria planilha no Google Drive, envia por e-mail e preenche o cabeçalho

--- a/colaborabot.py
+++ b/colaborabot.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from time import sleep
 import settings
 
-from divulga import lista_frases, checar_timelines, google_sshet
+from divulga import cria_frase, checar_timelines, google_sshet
 from autenticadores import twitter_auth, google_api_auth, masto_auth
 from gspread.exceptions import APIError
 
@@ -157,7 +157,7 @@ def busca_disponibilidade_sites(sites):
                         
                         for bots in settings.bracos:
                             bot = bots()
-                            bot.update(checa_timeline=True, mensagem=lista_frases(url=url, orgao=orgao))
+                            bot.update(checa_timeline=True, mensagem=cria_frase(url=url, orgao=orgao))
 
             except requests.exceptions.RequestException as e:
                 print("Tentativa {}:".format(tentativa + 1))

--- a/divulga.py
+++ b/divulga.py
@@ -12,8 +12,7 @@ def google_sshet():
     ggle_cred = gspread.Client(None, session)
     return ggle_cred
 
-# TODO renomear esta funcao para cria_frase
-def lista_frases(url, orgao):
+def cria_frase(url, orgao):
     com_orgao = [
         f"🤖 O portal com dados públicos {url} do órgão {orgao} parece não estar funcionando. Poderia me ajudar a checar?",
         f"🤖 Hum, parece que o site {url}, mantido pelo órgão {orgao}, está apresentando erro. Poderia dar uma olhadinha?",

--- a/divulga.py
+++ b/divulga.py
@@ -3,7 +3,7 @@ from autenticadores import google_api_auth
 from random import choice
 import gspread
 
-
+# TODO remover (?)
 def google_sshet():
     """
     Função simples para retornar um objeto capaz de manipular as planilhas do Google Sheets.
@@ -12,7 +12,7 @@ def google_sshet():
     ggle_cred = gspread.Client(None, session)
     return ggle_cred
 
-
+# TODO renomear esta funcao para cria_frase
 def lista_frases(url, orgao):
     com_orgao = [
         f"🤖 O portal com dados públicos {url} do órgão {orgao} parece não estar funcionando. Poderia me ajudar a checar?",
@@ -29,7 +29,7 @@ def lista_frases(url, orgao):
     msg_orgao = choice(com_orgao)
     return msg_orgao
 
-
+# TODO remover
 def checar_timelines(twitter_hander, mastodon_handler, url, orgao):
     """
     Recupera os 10 últimos toots/tweets da conta do Mastodon/Twitter.
@@ -39,6 +39,7 @@ def checar_timelines(twitter_hander, mastodon_handler, url, orgao):
 
     mastodon_bot = mastodon_handler
     twitter_bot = twitter_hander
+    
     timeline = mastodon_bot.timeline_home(limit=10)
     urls_postadas = [toot["content"] for toot in timeline]
     contem = any(url in toot for toot in urls_postadas)

--- a/divulga.py
+++ b/divulga.py
@@ -12,21 +12,6 @@ def google_sshet():
     ggle_cred = gspread.Client(None, session)
     return ggle_cred
 
-def cria_frase(url, orgao):
-    com_orgao = [
-        f"🤖 O portal com dados públicos {url} do órgão {orgao} parece não estar funcionando. Poderia me ajudar a checar?",
-        f"🤖 Hum, parece que o site {url}, mantido pelo órgão {orgao}, está apresentando erro. Poderia dar uma olhadinha?",
-        f"🤖 Poxa, tentei acessar {url} e não consegui. Este site é mantido pelo órgão {orgao}. Você pode confirmar isso?",
-        f"🤖 Não consigo acessar {url}, e eu sei que ele é mantido pelo órgão {orgao}. Você pode me ajudar a verificar?",
-        f"🤖 Sabe o portal {url}, mantido pelo orgão {orgao}? Ele parece estar fora do ar. Você pode confirmar?",
-        f"🤖 Parece que {url} está apresentando probleminhas para ser acessado. Alguém pode avisar a(o) {orgao}?",
-        f"🤖 Oi, parece que esse site {url} possui problemas de acesso. {orgao} está sabendo disso?",
-        f"🤖 Portais da transparência são um direito ao acesso à informação {orgao}, mas parece que {url} está fora do ar.",
-        f"🤖 Opa {orgao}, parece que o site {url} não está acessível como deveria. O que está acontecendo?",
-        f"🤖 Tentei acessar o site {url} e não consegui. {orgao} está acontecendo algum problema com essa portal de transparência?",
-    ]
-    msg_orgao = choice(com_orgao)
-    return msg_orgao
 
 # TODO remover
 def checar_timelines(twitter_hander, mastodon_handler, url, orgao):

--- a/settings.py
+++ b/settings.py
@@ -14,8 +14,13 @@ mastodon_key = config("DONTE_USERCRED")
 # [Plataforms IDs]
 mastodon_profile_id = config("ID_CONTA_MASTODON")
 
+# [Google API Keys / IDs]
+google_api_conf = "credenciais/colaborabot-gAPI.json"
+
 # [Bracos do Colabora Bot]
 import autenticadores
 bracos = (autenticadores.Twitter, 
           autenticadores.Mastodon,
+          autenticadores.GoogleSheet
 )
+

--- a/settings.py
+++ b/settings.py
@@ -19,8 +19,11 @@ google_api_conf = "credenciais/colaborabot-gAPI.json"
 
 # [Bracos do Colabora Bot]
 import autenticadores
-bracos = (autenticadores.Twitter, 
-          autenticadores.Mastodon,
-          autenticadores.GoogleSheet
+bracos = (
+#          autenticadores.Twitter, 
+#          autenticadores.Mastodon,
+#          autenticadores.GoogleSheet,
+#          autenticadores.Telegram,
+          autenticadores.CSV,
 )
 

--- a/settings.py
+++ b/settings.py
@@ -13,3 +13,9 @@ mastodon_key = config("DONTE_USERCRED")
 
 # [Plataforms IDs]
 mastodon_profile_id = config("ID_CONTA_MASTODON")
+
+# [Bracos do Colabora Bot]
+import autenticadores
+bracos = (autenticadores.Twitter, 
+          autenticadores.Mastodon,
+)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,30 @@
+from random import choice
+import datetime
+
+def cria_frase(url, orgao):
+    com_orgao = [
+        f"🤖 O portal com dados públicos {url} do órgão {orgao} parece não estar funcionando. Poderia me ajudar a checar?",
+        f"🤖 Hum, parece que o site {url}, mantido pelo órgão {orgao}, está apresentando erro. Poderia dar uma olhadinha?",
+        f"🤖 Poxa, tentei acessar {url} e não consegui. Este site é mantido pelo órgão {orgao}. Você pode confirmar isso?",
+        f"🤖 Não consigo acessar {url}, e eu sei que ele é mantido pelo órgão {orgao}. Você pode me ajudar a verificar?",
+        f"🤖 Sabe o portal {url}, mantido pelo orgão {orgao}? Ele parece estar fora do ar. Você pode confirmar?",
+        f"🤖 Parece que {url} está apresentando probleminhas para ser acessado. Alguém pode avisar a(o) {orgao}?",
+        f"🤖 Oi, parece que esse site {url} possui problemas de acesso. {orgao} está sabendo disso?",
+        f"🤖 Portais da transparência são um direito ao acesso à informação {orgao}, mas parece que {url} está fora do ar.",
+        f"🤖 Opa {orgao}, parece que o site {url} não está acessível como deveria. O que está acontecendo?",
+        f"🤖 Tentei acessar o site {url} e não consegui. {orgao} está acontecendo algum problema com essa portal de transparência?",
+    ]
+    msg_orgao = choice(com_orgao)
+    return msg_orgao
+
+def cria_dados(url, portal, resposta):
+    """
+    Captura as informações de hora e data da máquina, endereço da página e
+    resposta recebida e as prepara dentro de uma lista para inserir na tabela.
+    """
+    formato_data = "%Y-%m-%d %H:%m:%S"
+    momento = str(datetime.datetime.now().strftime(formato_data))
+    momento_utc = datetime.datetime.utcnow().strftime(formato_data)
+    dados = [momento, momento_utc, url, portal, resposta]
+    return dados
+


### PR DESCRIPTION
Este PR contém os commit iniciais para refatorar o código e, quando isso estiver concluído, resolver a issue #41 .

Proposta da solução:
- Deixar o código orientado a objetos
- Criar uma abstração Braço. Essa nomenclatura foi pensando quando vimos que ColaboraBot não era um bot apenas para Twitter, mas um bot com vários braços (Twitter, Mastodon, Google Sheet...)
- Cada braço será uma extensão da classe BraçoBase
- Os braços ativos estarão definidos em settings. Assim, se for preciso desativar um braço basta editar este arquivo.
- Esse configuração será lida no "boot" do bot e os bots ativos serão invocados sempre que for preciso atualizar o contexto do bot

O braço CSV foi o único testado. O "main" do Colaborabot também foi reescrito já para essa nova proposta.

Os braços de Twitter e Mastodon já estão com algum encaminhamento, embora sem nenhum teste em função das chaves das plataformas. O braço para Google Sheet está mais cru, pois o código das funções atuais referentes está mais complexo.

Também renomeamos e/ou excluimos alguns funções.

Para habilitar ou não um braço, basta editar a constante settings.bracos.

Por gentileza, executar  com as chaves e me informar dos problemas. 